### PR TITLE
remove unfinished score sorting and score display

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The background worker continuously maintains relation data for sequel awareness,
 
 The hardest part has been balancing freshness and resilience. Upstream APIs can fail transiently with `429` and `5xx` responses, so the app favors graceful degradation over hard failure. Cached values are used when fresh requests fail, retryable failures are persisted and replayed in the worker, and relation synchronization is incremental so one bad fetch does not block the rest of the graph.
 
-There are still honest limits. Score sorting in the watchlist remains a placeholder path, and metadata quality still depends partly on external providers. There is also no formal CI pipeline yet, so local validation is currently the main quality gate.
+There are still honest limits. Metadata quality still depends partly on external providers, and there is also no formal CI pipeline yet, so local validation is currently the main quality gate.
 
 ## Getting started
 

--- a/internal/features/watchlist/handler.go
+++ b/internal/features/watchlist/handler.go
@@ -152,7 +152,7 @@ func (h *Handler) HandleGetWatchlist(w http.ResponseWriter, r *http.Request) {
 	sortBy := r.URL.Query().Get("sort")
 	sortOrder := r.URL.Query().Get("order")
 
-	if sortBy != "title" && sortBy != "score" {
+	if sortBy != "title" {
 		sortBy = "date"
 	}
 	if sortOrder != "asc" {
@@ -269,11 +269,6 @@ func (h *Handler) sortEntries(entries []database.GetUserWatchListRow, sortBy, so
 				return cmp
 			}
 			return !cmp
-		}
-	case "score":
-		less = func(i, j int) bool {
-			// Score is stored as JSON in the DB, for now just keep default order
-			return false
 		}
 	default: // "date"
 		less = func(i, j int) bool {

--- a/internal/jikan/types.go
+++ b/internal/jikan/types.go
@@ -41,8 +41,6 @@ type Anime struct {
 		} `json:"webp"`
 	} `json:"images"`
 	Synopsis     string        `json:"synopsis"`
-	Score        float64       `json:"score"`
-	ScoredBy     int           `json:"scored_by"`
 	Rank         int           `json:"rank"`
 	Popularity   int           `json:"popularity"`
 	Status       string        `json:"status"`

--- a/internal/shared/ui/sort_filter.templ
+++ b/internal/shared/ui/sort_filter.templ
@@ -1,7 +1,7 @@
 package ui
 
 type SortFilterOptions struct {
-	Sort   string // "title", "date", "score"
+	Sort   string // "title", "date"
 	Order  string // "asc", "desc"
 	View   string // for watchlist: "grid", "table"
 	Status string // for watchlist: "all", "watching", etc
@@ -14,7 +14,6 @@ templ SortFilter(opts SortFilterOptions) {
 			<select id="sort-select" class="sort-filter-select" onchange="document.getElementById('sort-input').value = this.value; document.getElementById('sort-form').submit()">
 				<option value="date" selected?={ opts.Sort == "date" }>Date added</option>
 				<option value="title" selected?={ opts.Sort == "title" }>Title</option>
-				<option value="score" selected?={ opts.Sort == "score" }>Score</option>
 			</select>
 		</div>
 		<div class="sort-filter-group">

--- a/internal/templates/anime.templ
+++ b/internal/templates/anime.templ
@@ -82,12 +82,6 @@ templ AnimeDetails(anime jikan.Anime, currentStatus string) {
 							<span class="sidebar-value">{ anime.Status }</span>
 						</div>
 					}
-					if anime.Score > 0 {
-						<div class="sidebar-row">
-							<span class="sidebar-label">MAL Score</span>
-							<span class="sidebar-value">{ fmt.Sprintf("%.2f", anime.Score) }</span>
-						</div>
-					}
 					if anime.Duration != "" {
 						<div class="sidebar-row">
 							<span class="sidebar-label">Duration</span>


### PR DESCRIPTION
The watchlist still exposed score-based sorting even though that path was never fully implemented, which created a confusing experience and implied behavior the app did not actually support.

This change removes score sorting from the watchlist controls and handler logic, and also removes score display/fields that were only carried through for that incomplete path. The result is a simpler, more honest interface focused on behavior that is fully supported today.