### PR TITLE
remove jikan limit params to avoid catalog stalls

### DIFF
--- a/internal/features/anime/handler.go
+++ b/internal/features/anime/handler.go
@@ -127,7 +127,7 @@ func (h *Handler) HandleAPICatalog(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if fallbackPlaceholder {
-		templates.CatalogPlaceholderItems(jikan.ListPageSize).Render(r.Context(), w)
+		templates.CatalogPlaceholderItems(25).Render(r.Context(), w)
 		return
 	}
 

--- a/internal/jikan/constants.go
+++ b/internal/jikan/constants.go
@@ -2,6 +2,4 @@ package jikan
 
 import "time"
 
-const ListPageSize = 24
-
 const shortCacheTTL = time.Hour

--- a/internal/jikan/search.go
+++ b/internal/jikan/search.go
@@ -14,7 +14,7 @@ func (c *Client) Search(ctx context.Context, query string, page int) (SearchResu
 		page = 1
 	}
 
-	cacheKey := fmt.Sprintf("search:limit%d:%s:%d", ListPageSize, query, page)
+	cacheKey := fmt.Sprintf("search:%s:%d", query, page)
 	var cached SearchResult
 	if c.getCache(ctx, cacheKey, &cached) {
 		return cached, nil
@@ -24,7 +24,7 @@ func (c *Client) Search(ctx context.Context, query string, page int) (SearchResu
 	hasStale := c.getStaleCache(ctx, cacheKey, &stale)
 
 	var result SearchResponse
-	reqURL := fmt.Sprintf("%s/anime?q=%s&limit=%d&page=%d", c.baseURL, url.QueryEscape(query), ListPageSize, page)
+	reqURL := fmt.Sprintf("%s/anime?q=%s&page=%d", c.baseURL, url.QueryEscape(query), page)
 
 	if err := c.fetchWithRetry(ctx, reqURL, &result); err != nil {
 		if hasStale {
@@ -47,7 +47,7 @@ func (c *Client) GetTopAnime(ctx context.Context, page int) (TopAnimeResult, err
 	if page < 1 {
 		page = 1
 	}
-	cacheKey := fmt.Sprintf("top:limit%d:%d", ListPageSize, page)
+	cacheKey := fmt.Sprintf("top:%d", page)
 	var cached TopAnimeResult
 	if c.getCache(ctx, cacheKey, &cached) {
 		return cached, nil
@@ -57,7 +57,7 @@ func (c *Client) GetTopAnime(ctx context.Context, page int) (TopAnimeResult, err
 	hasStale := c.getStaleCache(ctx, cacheKey, &stale)
 
 	var result TopAnimeResponse
-	reqURL := fmt.Sprintf("%s/top/anime?filter=bypopularity&limit=%d&page=%d", c.baseURL, ListPageSize, page)
+	reqURL := fmt.Sprintf("%s/top/anime?page=%d", c.baseURL, page)
 
 	if err := c.fetchWithRetry(ctx, reqURL, &result); err != nil {
 		if hasStale {

--- a/internal/jikan/seasons.go
+++ b/internal/jikan/seasons.go
@@ -13,7 +13,7 @@ type ScheduleResult struct {
 
 func (c *Client) GetSchedule(ctx context.Context, day string) (ScheduleResult, error) {
 	day = strings.ToLower(day)
-	cacheKey := fmt.Sprintf("schedule_limit%d_%s", ListPageSize, day)
+	cacheKey := fmt.Sprintf("schedule_%s", day)
 
 	var cached ScheduleResult
 	if c.getCache(ctx, cacheKey, &cached) {
@@ -24,7 +24,7 @@ func (c *Client) GetSchedule(ctx context.Context, day string) (ScheduleResult, e
 	hasStale := c.getStaleCache(ctx, cacheKey, &stale)
 
 	var result TopAnimeResponse
-	reqURL := fmt.Sprintf("%s/schedules?filter=%s&sfw=true&limit=%d", c.baseURL, day, ListPageSize)
+	reqURL := fmt.Sprintf("%s/schedules?filter=%s&sfw=true", c.baseURL, day)
 	if err := c.fetchWithRetry(ctx, reqURL, &result); err != nil {
 		if hasStale {
 			return stale, nil
@@ -61,7 +61,7 @@ func (c *Client) GetSeasonsNow(ctx context.Context, page int) (TopAnimeResult, e
 	if page < 1 {
 		page = 1
 	}
-	cacheKey := fmt.Sprintf("seasons_now_limit%d:%d", ListPageSize, page)
+	cacheKey := fmt.Sprintf("seasons_now:%d", page)
 	var cached TopAnimeResult
 	if c.getCache(ctx, cacheKey, &cached) {
 		return cached, nil
@@ -71,7 +71,7 @@ func (c *Client) GetSeasonsNow(ctx context.Context, page int) (TopAnimeResult, e
 	hasStale := c.getStaleCache(ctx, cacheKey, &stale)
 
 	var result TopAnimeResponse
-	reqURL := fmt.Sprintf("%s/seasons/now?limit=%d&page=%d", c.baseURL, ListPageSize, page)
+	reqURL := fmt.Sprintf("%s/seasons/now?page=%d", c.baseURL, page)
 	if err := c.fetchWithRetry(ctx, reqURL, &result); err != nil {
 		if hasStale {
 			return stale, nil
@@ -93,7 +93,7 @@ func (c *Client) GetSeasonsUpcoming(ctx context.Context, page int) (TopAnimeResu
 	if page < 1 {
 		page = 1
 	}
-	cacheKey := fmt.Sprintf("seasons_upcoming_limit%d:%d", ListPageSize, page)
+	cacheKey := fmt.Sprintf("seasons_upcoming:%d", page)
 	var cached TopAnimeResult
 	if c.getCache(ctx, cacheKey, &cached) {
 		return cached, nil
@@ -103,7 +103,7 @@ func (c *Client) GetSeasonsUpcoming(ctx context.Context, page int) (TopAnimeResu
 	hasStale := c.getStaleCache(ctx, cacheKey, &stale)
 
 	var result TopAnimeResponse
-	reqURL := fmt.Sprintf("%s/seasons/upcoming?limit=%d&page=%d", c.baseURL, ListPageSize, page)
+	reqURL := fmt.Sprintf("%s/seasons/upcoming?page=%d", c.baseURL, page)
 	if err := c.fetchWithRetry(ctx, reqURL, &result); err != nil {
 		if hasStale {
 			return stale, nil


### PR DESCRIPTION
The catalog and discovery flows could get stuck in loading placeholders because some Jikan list endpoints were intermittently failing when called with explicit `limit` parameters.

This change removes explicit `limit` usage from the Jikan list requests and updates related cache keys to match the new request shape. It also updates the placeholder fallback count to align with the upstream default page size we now rely on.