### PR TITLE
fix: don't cache empty jikan responses

### DIFF
--- a/integrations/jikan/client.go
+++ b/integrations/jikan/client.go
@@ -271,6 +271,12 @@ func (c *Client) getWithCache(ctx context.Context, cacheKey string, ttl time.Dur
 		return err
 	}
 
+	// Don't cache empty results to avoid caching failures
+	if isEmptyResult(out) {
+		log.Printf("jikan: fetched data for %s is empty, not caching", cacheKey)
+		return fmt.Errorf("jikan: empty response for %s", cacheKey)
+	}
+
 	c.setCache(ctx, cacheKey, out, ttl)
 	return nil
 }


### PR DESCRIPTION
## summary
- prevent caching empty API responses from jikan to avoid infinite refetch loops
- fixes home page stuck on "loading catalog" when cache contains empty data

## testing
- verified empty responses are not cached
- home page will now either load or show error instead of hanging